### PR TITLE
Add simple multiplayer guess game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# marvel
+# Marvel Multiplayer Guess Game
+
+This project turns the original Marvel API demo into a simple multiplayer guessing game. The server fetches a list of characters from the Marvel API and players compete to guess which hero was chosen.
+
+## Setup
+
+1. Run `npm install` to install dependencies.
+2. Create a `.env` file and set `MARVEL_PUBLIC_KEY` and `MARVEL_PRIVATE_KEY` with your API credentials.
+3. Start the server with `npm start`.
+4. Open `http://localhost:3000` in multiple browsers or devices to play with friends.
+
+When the game starts you'll see a clue showing the first letter of a random Marvel hero. Send guesses and the server will broadcast results to all connected players.

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "marvel",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "author": "",
   "license": "ISC",

--- a/public/client.js
+++ b/public/client.js
@@ -1,0 +1,21 @@
+const name = prompt('Enter your name') || 'Player'
+const messages = document.getElementById('messages')
+const guessInput = document.getElementById('guess')
+
+const source = new EventSource('/stream')
+source.onmessage = (e) => {
+    const li = document.createElement('li')
+    li.textContent = e.data
+    messages.appendChild(li)
+}
+
+function sendGuess(){
+    const guess = guessInput.value
+    if(!guess) return
+    fetch('/guess', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ name, guess })
+    })
+    guessInput.value = ''
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Marvel Guess Game</title>
+</head>
+<body>
+  <h1>Marvel Guess Game</h1>
+  <ul id="messages"></ul>
+  <input id="guess" placeholder="Your guess" />
+  <button onclick="sendGuess()">Send</button>
+  <script src="client.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,26 +1,76 @@
 require('dotenv').config()
+const express = require('express')
 const md5 = require('md5')
+
+const app = express()
+app.use(express.static('public'))
+app.use(express.json())
 
 const ts = new Date().getTime()
 const apikey = process.env.MARVEL_PUBLIC_KEY
 const privatekey = process.env.MARVEL_PRIVATE_KEY
-const hash =  md5(`${ts}${privatekey}${apikey}`)
-console.log(`the hash: ${hash} time ${ts} apikey ${apikey} ${privatekey}`)
+const hash = md5(`${ts}${privatekey}${apikey}`)
 
-const uri = 'comics'
+let characters = []
+let currentHero = null
+const clients = []
 
-
-const fetchData = async(uri) =>{
+async function fetchCharacters(){
     try{
-
-        const url = `http://gateway.marvel.com/v1/public/${uri}?ts=${ts}&apikey=${apikey}&hash=${hash}`
-        const results = await fetch(url)
-        const response = await results.json()
-        console.log(response)
-    }
-    catch(err){
-        console.log(err)
+        const url = `http://gateway.marvel.com/v1/public/characters?limit=100&ts=${ts}&apikey=${apikey}&hash=${hash}`
+        const res = await fetch(url)
+        const json = await res.json()
+        characters = json.data.results.map(c => c.name)
+    }catch(err){
+        console.error('Error fetching characters', err)
     }
 }
 
-fetchData(uri)
+function broadcast(msg){
+    clients.forEach(res => res.write(`data: ${msg}\n\n`))
+    console.log('Broadcast:', msg)
+}
+
+function newRound(){
+    if(characters.length === 0) return
+    currentHero = characters[Math.floor(Math.random() * characters.length)]
+    broadcast(`New round! Guess the hero. First letter: ${currentHero[0]}`)
+}
+
+app.get('/stream', (req, res) => {
+    res.setHeader('Content-Type', 'text/event-stream')
+    res.setHeader('Cache-Control', 'no-cache')
+    res.setHeader('Connection', 'keep-alive')
+    res.flushHeaders()
+    clients.push(res)
+    req.on('close', () => {
+        const idx = clients.indexOf(res)
+        if(idx !== -1) clients.splice(idx, 1)
+    })
+})
+
+app.post('/guess', (req, res) => {
+    const { name, guess } = req.body
+    if(!currentHero){
+        res.json({ error: 'Game not ready' })
+        return
+    }
+    if(guess && guess.toLowerCase() === currentHero.toLowerCase()){
+        broadcast(`${name} guessed correctly! The hero was ${currentHero}.`)
+        newRound()
+    } else {
+        broadcast(`${name} guessed ${guess}`)
+    }
+    res.json({ ok: true })
+})
+
+async function start(){
+    await fetchCharacters()
+    newRound()
+    const port = process.env.PORT || 3000
+    app.listen(port, () => {
+        console.log(`Game server running at http://localhost:${port}`)
+    })
+}
+
+start()


### PR DESCRIPTION
## Summary
- build express server that serves a basic multiplayer guessing game
- fetch a list of Marvel heroes and start rounds with SSE
- add minimal HTML/JS client in `public` directory
- update package.json entry point and README instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(failed: E403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68421264d58c8331a38deabef7b9f7a7